### PR TITLE
Import records via SQLite's builtin .import command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,14 @@ SHELL := bash -euo pipefail
 
 .PHONY: data/sfs-redcap.sqlite venv requirements.txt
 
-data/sfs-redcap.sqlite: data/record-barcodes.ndjson indexes.sql derived-tables.sql
+data/sfs-redcap.sqlite: data/record-barcodes.csv import.sql indexes.sql derived-tables.sql
 	sqlite3 $@ 'PRAGMA journal_mode=WAL;'
 	chmod -v g+w $@
-	sqlite-utils insert --nl --truncate $@ record_barcodes_new $<
-	sqlite3 $@ 'begin transaction; drop table if exists record_barcodes; alter table record_barcodes_new rename to record_barcodes; commit;'
+	sqlite3 $@ < import.sql
 	sqlite3 $@ < indexes.sql
 	sqlite3 $@ < derived-tables.sql
 
-data/record-barcodes.ndjson:
+data/record-barcodes.csv:
 	./bin/export-record-barcodes > $@
 
 venv:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can build the _data/sfs-redcap.sqlite_ database with:
 Data will be exported from REDCap the first time `make` is run.  Subsequent
 times will rebuild the SQLite database but not re-fetch from REDCap unless you
 pass the `-B` / `--always-make` option (or delete
-_data/record-barcodes.ndjson_).
+_data/record-barcodes.csv_).
 
 You'll need to provide several environment variables with REDCap API
 credentials:

--- a/bin/export-record-barcodes
+++ b/bin/export-record-barcodes
@@ -2,8 +2,9 @@
 import os
 import json
 import logging
-from sys import stderr
-from concurrent.futures import ThreadPoolExecutor
+from csv import DictWriter
+from sys import stdout, stderr
+from concurrent.futures import as_completed, ThreadPoolExecutor
 from id3c.cli import redcap
 from os import environ
 from typing import Optional, Dict
@@ -46,12 +47,25 @@ BARCODE_FIELDS = [
     "collection_barcode",
 ]
 
-FIELDS = [
+REDCAP_FIELDS = [
     "record_id",
     "redcap_event_name",
     "back_end_scan_date",  # used for record disambiguation
     "redcap_repeat_instance",
     "post_collection_data_entry_qc_complete",  # used to see if we can deep link to the PCDEQC form
+    *BARCODE_FIELDS,
+]
+
+OUTPUT_FIELDS = [
+    "project_id",
+    "project_lang",
+    "project_purview",
+    "record_id",
+    "event_name",
+    "repeat_instance",
+    "record_url",
+    "record_link",
+    "back_end_scan_date",
     *BARCODE_FIELDS,
 ]
 
@@ -296,13 +310,27 @@ def main():
         }),
     ]
 
+    csv = DictWriter(stdout, fieldnames = OUTPUT_FIELDS, dialect = "unix")
+    csv.writeheader()
+    stdout.flush()
+
     with ThreadPoolExecutor(5) as pool:
-        for project_records in pool.map(lambda p: list(fetch_records(p)), projects):
+        futures = [
+            pool.submit(fetch_records, p)
+                for p in projects ]
+
+        results = (f.result() for f in as_completed(futures))
+
+        for project_records in results:
             for record in project_records:
-                print(json.dumps(record, indent = None, separators = ",:"), flush = True)
+                csv.writerow(record)
 
 
 def fetch_records(project):
+    return list(_fetch_records(project))
+
+
+def _fetch_records(project):
     log.debug(f'Parsing project {project.id}')
 
     if project._details["is_longitudinal"]:
@@ -310,7 +338,7 @@ def fetch_records(project):
             event["unique_event_name"]: event["arm_num"]
                 for event in project._fetch("event") }
 
-    for record in project.records(fields=FIELDS, raw=True, page_size=project.fetch_page_size):
+    for record in project.records(fields=REDCAP_FIELDS, raw=True, page_size=project.fetch_page_size):
         query_params = {
             "pid": project.id,
             "id": record.id,

--- a/bin/export-record-barcodes
+++ b/bin/export-record-barcodes
@@ -338,7 +338,7 @@ def _fetch_records(project):
             event["unique_event_name"]: event["arm_num"]
                 for event in project._fetch("event") }
 
-    for record in project.records(fields=REDCAP_FIELDS, raw=True, page_size=project.fetch_page_size):
+    for record in project.records(fields=REDCAP_FIELDS, filter=has_any_barcode(project), raw=True, page_size=project.fetch_page_size):
         query_params = {
             "pid": project.id,
             "id": record.id,
@@ -395,6 +395,11 @@ def _fetch_records(project):
             data['event_name'] = event_name
 
         yield data
+
+
+def has_any_barcode(project):
+    fields = set(BARCODE_FIELDS) & set(f["field_name"] for f in project.fields)
+    return " or ".join(f"[{field}] <> ''" for field in fields)
 
 
 def normalize_barcode(barcode):

--- a/bin/export-record-barcodes
+++ b/bin/export-record-barcodes
@@ -189,7 +189,7 @@ def main():
         # event_id.
         Project(23854, "en", "irb", {
             'encounter_arm_1': 742155,
-        }, 1000),
+        }, 5000),
 
         # Childcare Study
         Project(23740, "en", "irb", {

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,0 @@
-# Constraints to avoid upgrading these in the switch from Pipenv → pip-tools.
-# ID3C is constrained directly in requirements.in via the git commit id.
-sqlite-utils ==2.11

--- a/import.sql
+++ b/import.sql
@@ -1,0 +1,11 @@
+begin;
+
+-- When the table doesn't exist, .import assumes the first line of the CSV is a
+-- header line (instead of data line) and automatically create the table based
+-- on it.
+drop table if exists record_barcodes;
+
+.mode csv
+.import data/record-barcodes.csv record_barcodes
+
+commit;

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 -c constraints.txt
 
-id3c @ https://github.com/seattleflu/id3c/archive/31a711e62c9a9e1516efb0a32d463275fa65ad5e.tar.gz
+id3c @ https://github.com/seattleflu/id3c/archive/a8a9d950d7dcba373fd46dc57cd228ed4c627e6a.tar.gz
 datasette >=0.55
 sqlite-utils >=2.11

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,2 @@
--c constraints.txt
-
 id3c @ https://github.com/seattleflu/id3c/archive/a8a9d950d7dcba373fd46dc57cd228ed4c627e6a.tar.gz
 datasette >=0.55
-sqlite-utils >=2.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -98,9 +98,7 @@ chardet==3.0.4 \
     #   requests
 click-default-group==1.2.2 \
     --hash=sha256:d9560e8e8dfa44b3562fbc9425042a0fd6d21956fcc2db0077f63f34253ab904
-    # via
-    #   datasette
-    #   sqlite-utils
+    # via datasette
 click-plugins==1.1.1 \
     --hash=sha256:46ab999744a9d831159c3411bb0c79346d94a444df9a3a3742e9ed63645f264b \
     --hash=sha256:5d262006d3222f5057fd81e1623d4443e41dcda5dc815c06b442aa3c02889fc8
@@ -116,7 +114,6 @@ click==7.1.2 \
     #   fiona
     #   flask
     #   id3c
-    #   sqlite-utils
     #   uvicorn
 cligj==0.7.1 \
     --hash=sha256:07171c1e287f45511f97df4ea071abc5d19924153413d5683a8e4866369bc676 \
@@ -587,15 +584,6 @@ sniffio==1.2.0 \
     # via
     #   httpcore
     #   httpx
-sqlite-utils==2.11 \
-    --hash=sha256:688ef44fdbb1a4c9a188d87c976562f659d8b29dc6dcc872d1cd7748d1c99ec9
-    # via
-    #   -c constraints.txt
-    #   -r requirements.in
-tabulate==0.8.7 \
-    --hash=sha256:ac64cb76d53b1231d364babcd72abbb16855adac7de6665122f97b593f1eb2ba \
-    --hash=sha256:db2723a20d04bcda8522165c73eea7c300eda74e0ce852d9022e0159d7895007
-    # via sqlite-utils
 typing-extensions==3.7.4.3 \
     --hash=sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918 \
     --hash=sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c \

--- a/requirements.txt
+++ b/requirements.txt
@@ -217,8 +217,8 @@ hupper==1.10.2 \
     --hash=sha256:3818f53dabc24da66f65cf4878c1c7a9b5df0c46b813e014abdd7c569eb9a02a \
     --hash=sha256:5de835f3b58324af2a8a16f52270c4d1a3d1734c45eed94b77fd622aea737f29
     # via datasette
-https://github.com/seattleflu/id3c/archive/31a711e62c9a9e1516efb0a32d463275fa65ad5e.tar.gz \
-    --hash=sha256:b1981f4b00fed5db1a99754166af3458e0b93ba1f922e0bd5943f8716ef67fe3
+https://github.com/seattleflu/id3c/archive/a8a9d950d7dcba373fd46dc57cd228ed4c627e6a.tar.gz \
+    --hash=sha256:376a0419ebab9c85bd9442eff3bac83e13312461de452490014ea9fdbaa0b3a5
     # via -r requirements.in
 idna-ssl==1.1.0 \
     --hash=sha256:a933e3bb13da54383f9e8f35dc4f9cb9eb9b3b78c6b36f311254d6d0d92c6c7c


### PR DESCRIPTION
Reduces import time from ~10 min to ~1 min.

Requires switching from NDJSON to CSV, but we now no longer need the
sqlite-utils program and can embed the .import command within a
transaction ourselves instead of importing into a second table and
renaming.