### PR TITLE
Generate record link JSON at query time

### DIFF
--- a/bin/export-record-barcodes
+++ b/bin/export-record-barcodes
@@ -72,7 +72,7 @@ OUTPUT_FIELDS = [
     "event_name",
     "repeat_instance",
     "record_url",
-    "record_link",
+    "record_link_label",
     "back_end_scan_date",
     *BARCODE_FIELDS,
 ]
@@ -386,10 +386,7 @@ def _fetch_records(project):
             "record_id": record.id,
             "repeat_instance": record.get("redcap_repeat_instance"),  # Used in duplicate disambiguation
             "record_url": record_url,
-            "record_link": {
-                "href": record_url,
-                "label": f"{record.id} ({project.lang})",
-            },
+            "record_link_label": f"{record.id} ({project.lang})",
             "back_end_scan_date": record.get("back_end_scan_date"),
 
             # The barcode fields were made optional for the SCAN IRB Kiosk project

--- a/datasette.yaml
+++ b/datasette.yaml
@@ -11,7 +11,7 @@ databases:
         title: Barcode lookup
         sql: |
           select
-            record_link as record,
+            '{"href": "' || record_url || '", "label": "' || record_link_label || '"}' as record,
             event_name,
             back_end_scan_date,
             pre_scan_barcode,

--- a/derived-tables.sql
+++ b/derived-tables.sql
@@ -20,7 +20,7 @@ create table duplicate_record_ids as
         having count(*) > 1
     )
     select
-        record_link as record,
+        '{"href": "' || record_url || '", "label": "' || record_link_label || '"}' as record,
         event_name,
         pre_scan_barcode,
         utm_tube_barcode_2,


### PR DESCRIPTION
The CSV DictWriter was writing the JSON for the `record_link` column
using a single quote instead of a double quote around the JSON key names
and values. This was causing a `json.loads` error in html_links.py.

With this change, we don't store the JSON in the table. Instead,
at query time, the SQL concatenates to build the JSON. The two components
that go into the JSON are `record_url` which was already a column
and a new column named `record_link_label`.