### PR TITLE
Record link serialization

### DIFF
--- a/bin/export-record-barcodes
+++ b/bin/export-record-barcodes
@@ -72,7 +72,7 @@ OUTPUT_FIELDS = [
     "event_name",
     "repeat_instance",
     "record_url",
-    "record_link_label",
+    "record_link",
     "back_end_scan_date",
     *BARCODE_FIELDS,
 ]
@@ -386,7 +386,10 @@ def _fetch_records(project):
             "record_id": record.id,
             "repeat_instance": record.get("redcap_repeat_instance"),  # Used in duplicate disambiguation
             "record_url": record_url,
-            "record_link_label": f"{record.id} ({project.lang})",
+            "record_link": {
+                "href": record_url,
+                "label": f"{record.id} ({project.lang})",
+            },
             "back_end_scan_date": record.get("back_end_scan_date"),
 
             # The barcode fields were made optional for the SCAN IRB Kiosk project

--- a/bin/export-record-barcodes
+++ b/bin/export-record-barcodes
@@ -6,6 +6,7 @@ from csv import DictWriter
 from sys import stdout, stderr
 from concurrent.futures import as_completed, ThreadPoolExecutor
 from id3c.cli import redcap
+from id3c.json import as_json
 from os import environ
 from typing import Optional, Dict
 from urllib.parse import urlencode, urljoin
@@ -386,10 +387,10 @@ def _fetch_records(project):
             "record_id": record.id,
             "repeat_instance": record.get("redcap_repeat_instance"),  # Used in duplicate disambiguation
             "record_url": record_url,
-            "record_link": {
+            "record_link": as_json({
                 "href": record_url,
                 "label": f"{record.id} ({project.lang})",
-            },
+            }),
             "back_end_scan_date": record.get("back_end_scan_date"),
 
             # The barcode fields were made optional for the SCAN IRB Kiosk project

--- a/datasette.yaml
+++ b/datasette.yaml
@@ -11,7 +11,7 @@ databases:
         title: Barcode lookup
         sql: |
           select
-            '{"href": "' || record_url || '", "label": "' || record_link_label || '"}' as record,
+            record_link as record,
             event_name,
             back_end_scan_date,
             pre_scan_barcode,

--- a/derived-tables.sql
+++ b/derived-tables.sql
@@ -20,7 +20,7 @@ create table duplicate_record_ids as
         having count(*) > 1
     )
     select
-        '{"href": "' || record_url || '", "label": "' || record_link_label || '"}' as record,
+        record_link as record,
         event_name,
         pre_scan_barcode,
         utm_tube_barcode_2,


### PR DESCRIPTION
Serialize the record_link as JSON, instead of Python's repr()

With the switch from NDJSON → CSV, this dictionary-valued column
unintentionally switched from being serialized as JSON to being
stringified with Python's repr().  Our SQLite plugin for producing links
expects JSON.

