### PR TITLE
Include CLIA barcodes in dataset

### DIFF
--- a/bin/export-record-barcodes
+++ b/bin/export-record-barcodes
@@ -53,6 +53,15 @@ BARCODE_FIELDS = [
     "outgoing_barcode",
     "core_activation_barcode",
     "collection_barcode",
+
+    # CLIA
+    "clia_barcode_verify",
+    "clia_id",
+    "core_clia_barcode",
+    "return_clia_barcode",
+    "scan_id",
+    "scan_id_kiosk",
+    "scan_id_manual",
 ]
 
 REDCAP_FIELDS = [


### PR DESCRIPTION
Looking up REDCap records by CLIA barcode is useful when the collection
barcode is missing or wrong.

I created this list of fields by programmatically querying the fields of
all projects we interact with, grepping for any that mention CLIA, and
then manually reviewing/curating from there.