### PR TITLE
Add scan tiny swab project

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ credentials:
     REDCAP_API_TOKEN_redcap.iths.org_32756
     REDCAP_API_TOKEN_redcap.iths.org_34101
     REDCAP_API_TOKEN_redcap.iths.org_34701
+    REDCAP_API_TOKEN_redcap.iths.org_45732
     REDCAP_API_TOKEN_hct.redcap.rit.uw.edu_45
 
 These are the same variables used in the [backoffice/id3c-production/env.d/redcap/] envdir.

--- a/bin/export-record-barcodes
+++ b/bin/export-record-barcodes
@@ -63,6 +63,10 @@ BARCODE_FIELDS = [
     "scan_id",
     "scan_id_kiosk",
     "scan_id_manual",
+
+    # SCAN: Tiny Swabs
+    "ans_collection_id",
+    "tiny_collection_id",
 ]
 
 REDCAP_FIELDS = [
@@ -212,6 +216,9 @@ def main():
             'asymptomatic_arm_3': 739634,
             'group_enroll_arm_4': 739635,
         }),
+
+        # SCAN: Tiny Swabs (usability study)
+        Project(45732, ITHS_REDCAP_API_URL, "en", "irb", None),
 
         # We're skipping REDCap PID 23959 (SCAN: Husky Test), because this
         # was a one-off project that only had enrollments for a couple of weeks


### PR DESCRIPTION
Adding the SCAN: Tiny Swabs project to switchboard. This project design
includes two new field names that are being used to store barcodes.
Those are added to the list of barcode fields to be included during export.