### PR TITLE
Disable REDCap Project 34101 from Switchboard

### DIFF
--- a/bin/export-record-barcodes
+++ b/bin/export-record-barcodes
@@ -241,7 +241,7 @@ def main():
         Project(45, HCT_REDCAP_API_URL, "en", "irb", {
             'encounter_arm_1': 129,
         }, 5000),
-        
+
         # Childcare Study
         Project(23740, ITHS_REDCAP_API_URL, "en", "irb", {
             'enrollment_arm_1': 742420,
@@ -388,7 +388,7 @@ def main():
             'serial_event_3_arm_1': 769743,
             'serial_event_4_arm_1': 769744,
         }),
-
+        """
         # Yakima School Radxup Testing
         # English
         Project(34101, ITHS_REDCAP_API_URL, "en", "irb", {
@@ -406,6 +406,7 @@ def main():
             'enrollment_arm_2': 779706,
             'week_2_arm_2': 779711,
         }),
+        """
         # Spanish
         Project(34701, ITHS_REDCAP_API_URL, "es", "irb", {
            'enrollment_arm_1': 781056,


### PR DESCRIPTION
Overnight, the API token being used for this project on the backoffice server became invalid and is affecting the Switchboard refresh job. A majority of the team have lost access to the project. As a temporary fix, the project is commented out of the Switchboard pipeline. This project does not receive any new samples and is currently on cleanup/analysis on REDCap.