### PR TITLE
Disable REDCap Project 34101 from Switchboard - Correction

### DIFF
--- a/bin/export-record-barcodes
+++ b/bin/export-record-barcodes
@@ -388,25 +388,23 @@ def main():
             'serial_event_3_arm_1': 769743,
             'serial_event_4_arm_1': 769744,
         }),
-        """
         # Yakima School Radxup Testing
         # English
-        Project(34101, ITHS_REDCAP_API_URL, "en", "irb", {
-            'enrollment_arm_1': 779626,
-            'week_1_arm_1': 779631,
-            'week_2_arm_1': 779636,
-            'week_3_arm_1': 779641,
-            'week_4_arm_1': 779646,
-            'week_5_arm_1': 779651,
-            'week_6_arm_1': 779656,
-            'week_7_arm_1': 779661,
-            'week_8_arm_1': 779666,
-            'week_9_arm_1': 779671,
-            'week_10_arm_1': 779676,
-            'enrollment_arm_2': 779706,
-            'week_2_arm_2': 779711,
-        }),
-        """
+        # Project(34101, ITHS_REDCAP_API_URL, "en", "irb", {
+            # 'enrollment_arm_1': 779626,
+            # 'week_1_arm_1': 779631,
+            # 'week_2_arm_1': 779636,
+            # 'week_3_arm_1': 779641,
+            # 'week_4_arm_1': 779646,
+            # 'week_5_arm_1': 779651,
+            # 'week_6_arm_1': 779656,
+            # 'week_7_arm_1': 779661,
+            # 'week_8_arm_1': 779666,
+            # 'week_9_arm_1': 779671,
+            # 'week_10_arm_1': 779676,
+            # 'enrollment_arm_2': 779706,
+            # 'week_2_arm_2': 779711,
+        # }),
         # Spanish
         Project(34701, ITHS_REDCAP_API_URL, "es", "irb", {
            'enrollment_arm_1': 781056,


### PR DESCRIPTION
Correction to last deployment: Project of interest is commented out with # at the beginning of each line instead of multiline comment syntax.

Testing: Was not able to test locally b/c I do not have API export privileges for many old pre-IRB REDCap projects, thus could not run `make`.

Context: Overnight, the API token being used for this project on the backoffice server became invalid and is affecting the Switchboard refresh job. A majority of the team have lost access to the project. As a temporary fix, the project is commented out of the Switchboard pipeline. This project does not receive any new samples and is currently on cleanup/analysis on REDCap.