### PR TITLE
Remove Yakima Studies from Project List

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,6 @@ credentials:
     REDCAP_API_TOKEN_redcap.iths.org_24499
     REDCAP_API_TOKEN_redcap.iths.org_32751
     REDCAP_API_TOKEN_redcap.iths.org_32756
-    REDCAP_API_TOKEN_redcap.iths.org_34101
-    REDCAP_API_TOKEN_redcap.iths.org_34701
     REDCAP_API_TOKEN_redcap.iths.org_45732
     REDCAP_API_TOKEN_hct.redcap.rit.uw.edu_45
 

--- a/bin/export-record-barcodes
+++ b/bin/export-record-barcodes
@@ -37,7 +37,7 @@ BARCODE_FIELDS = [
     "collect_barcode_kiosk",
     "barcode_swabsend",
 
-    # Childcare, Snohomish Schools, Yakima Schools
+    # Childcare, Snohomish Schools
     *[f'barcode_{i}' for i in range(1,35)],
     *[f'barcode_optional_{i}' for i in range(1,5)],
     "barcode_ex1",
@@ -387,39 +387,6 @@ def main():
             'serial_event_2_arm_1': 769742,
             'serial_event_3_arm_1': 769743,
             'serial_event_4_arm_1': 769744,
-        }),
-        # Yakima School Radxup Testing
-        # English
-        # Project(34101, ITHS_REDCAP_API_URL, "en", "irb", {
-            # 'enrollment_arm_1': 779626,
-            # 'week_1_arm_1': 779631,
-            # 'week_2_arm_1': 779636,
-            # 'week_3_arm_1': 779641,
-            # 'week_4_arm_1': 779646,
-            # 'week_5_arm_1': 779651,
-            # 'week_6_arm_1': 779656,
-            # 'week_7_arm_1': 779661,
-            # 'week_8_arm_1': 779666,
-            # 'week_9_arm_1': 779671,
-            # 'week_10_arm_1': 779676,
-            # 'enrollment_arm_2': 779706,
-            # 'week_2_arm_2': 779711,
-        # }),
-        # Spanish
-        Project(34701, ITHS_REDCAP_API_URL, "es", "irb", {
-           'enrollment_arm_1': 781056,
-            'week_1_arm_1': 781061,
-            'week_2_arm_1': 781066,
-            'week_3_arm_1': 781071,
-            'week_4_arm_1': 781076,
-            'week_5_arm_1': 781081,
-            'week_6_arm_1': 781086,
-            'week_7_arm_1': 781091,
-            'week_8_arm_1': 781096,
-            'week_9_arm_1': 781101,
-            'week_10_arm_1': 781106,
-            'enrollment_arm_2': 781136,
-            'week_2_arm_2': 781141,
         }),
     ]
 


### PR DESCRIPTION
We recently lost access to the Yakima study (REDCap PID 34101) and will not be getting our access back, so are removing it from the project list. Also included this change is the removal of the Spanish Pilot version of this study (PID 34701) which we still have access to but will likely lose in the future. This change will preempt those run failures for the Spanish project.