### PR TITLE
Batch Data Export Requests for SCAN English

### DIFF
--- a/bin/export-record-barcodes
+++ b/bin/export-record-barcodes
@@ -114,7 +114,7 @@ def main():
             'symptomatic_arm_2': 737706,
             'asymptomatic_arm_3': 737707,
             'group_enroll_arm_4': 737754
-        }),
+        }, 20000),
         Project(22472, ITHS_REDCAP_API_URL, "ru", "irb", {
             'priority_arm_1': 737728,
             'symptomatic_arm_2': 737729,


### PR DESCRIPTION
The switchboard job has been timing out more recently. This change batches
data export requests to the SCAN English project to hopefully reduce the
load on the REDCap API during the switchboard refresh job to prevent timeouts
when exporting data.